### PR TITLE
Add root path alias for imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules/
+.next/
+dist/
+.env
+.env.local
+.env.development
+.env.test
+.env.production
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,11 +14,13 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "baseUrl": ".",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
     "paths": {
+      "@/*": ["./*"],
       "@/components/*": ["./components/*"],
       "@/lib/*": ["./lib/*"],
       "@/store/*": ["./store/*"],


### PR DESCRIPTION
## Summary
- add `@/*` alias to tsconfig so imports like `@/app/globals.css` resolve

## Testing
- `npm test` (fails: Playwright Test did not expect test.describe)
- `npm run lint` (fails: Failed to load config "prettier" to extend from)
- `npm run build` (fails: ESLint config "prettier" missing; TS error in BattleArena.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68ad0512aca08323996a367924d99cae