### PR TITLE
feat: improve battle flow

### DIFF
--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -12,6 +12,7 @@ import { BattleArena } from '@/components/BattleArena';
 import { LogPanel } from '@/components/LogPanel';
 import { TeamPanel } from '@/components/TeamPanel';
 import { UpgradePanel } from '@/components/UpgradePanel';
+import { ProgressBar } from '@/components/ProgressBar';
 import { useTranslate } from '@/hooks/useTranslate';
 
 export default function GamePage() {
@@ -87,8 +88,16 @@ export default function GamePage() {
           <div className="text-sm">
             {t('level')}: {player.level}
           </div>
-          <div className="text-sm">
-            {t('experience')}: {player.xp}
+          <div className="text-sm flex items-center space-x-2">
+            <span>
+              {t('experience')}: {player.xp}
+            </span>
+            <ProgressBar
+              value={player.xp - (player.level - 1) * 100}
+              max={100}
+              color="yellow"
+              className="w-24"
+            />
           </div>
           <div className="text-sm">
             {t('coins')}: {player.coins}

--- a/components/BattleArena.tsx
+++ b/components/BattleArena.tsx
@@ -109,11 +109,6 @@ export function BattleArena() {
             {t('nextBattle')}
           </button>
         )}
-        {status === 'lost' && (
-          <div className="text-red-500 font-semibold">
-            You lost! Reset progress and try again.
-          </div>
-        )}
       </div>
     </div>
   );
@@ -132,7 +127,7 @@ function createMaxHp(member: {
   // @ts-ignore
   if (member[key]) return member[key];
   // @ts-ignore
-  member[key] = createBattlePokemon(member.pokemon, member.level).hp;
+  member[key] = createBattlePokemon(member.pokemon, member.level, true).hp;
   return member[key];
 }
 

--- a/components/TeamPanel.tsx
+++ b/components/TeamPanel.tsx
@@ -58,6 +58,6 @@ function createMaxHp(member: { pokemon: any; level: number; hp: number }): numbe
   if (member[key]) return member[key];
   // compute once
   // @ts-ignore
-  member[key] = createBattlePokemon(member.pokemon, member.level).hp;
+  member[key] = createBattlePokemon(member.pokemon, member.level, true).hp;
   return member[key];
 }

--- a/lib/battle/engine.ts
+++ b/lib/battle/engine.ts
@@ -1,5 +1,6 @@
 import { NormalisedPokemon } from '@/lib/pokeapi';
 import { BASIC_MOVES, Move } from '@/lib/battle/moves';
+import { calcHpBonus } from '@/lib/progression/progression';
 import type {
   BattlePokemon,
   DamageResult,
@@ -43,14 +44,16 @@ function getMovesForPokemon(pokemon: NormalisedPokemon): Move[] {
  */
 export function createBattlePokemon(
   pokemon: NormalisedPokemon,
-  level: number
+  level: number,
+  isPlayer = false
 ): BattlePokemon {
   const levelMultiplier = 1 + (level - 1) * 0.02;
-  const hp = Math.round(pokemon.stats.hp * levelMultiplier);
+  const baseHp = Math.round(pokemon.stats.hp * levelMultiplier);
+  const bonus = isPlayer ? calcHpBonus(level) : 0;
   const moves = getMovesForPokemon(pokemon);
   return {
     pokemon,
-    hp,
+    hp: baseHp + bonus,
     level,
     cooldowns: new Array(moves.length).fill(0)
   };

--- a/lib/progression/progression.ts
+++ b/lib/progression/progression.ts
@@ -29,6 +29,15 @@ export function calcLevelFromXp(xp: number): number {
   return Math.max(1, Math.floor(xp / 100) + 1);
 }
 
+/**
+ * Returns an additional HP bonus for the player's Pokémon based on level.
+ * Granting some extra health at low levels makes early battles less
+ * punishing while still allowing difficulty to scale over time.
+ */
+export function calcHpBonus(level: number): number {
+  return 20 + (level - 1) * 5;
+}
+
 export type UpgradeType =
   | 'hp'
   | 'attack'

--- a/store/battleStore.ts
+++ b/store/battleStore.ts
@@ -37,7 +37,7 @@ export const useBattleStore = create<BattleState>((set, get) => ({
     if (!enemy) return;
     set({ status: 'running', log: [] });
     // Create battle participants
-    const playerActive = createBattlePokemon(team[0].pokemon, team[0].level);
+    const playerActive = createBattlePokemon(team[0].pokemon, team[0].level, true);
     const enemyBattle = createBattlePokemon(enemy, get().enemyLevel);
     // Initialise HP for animation
     set({ playerHp: playerActive.hp, enemyHp: enemyBattle.hp });
@@ -81,8 +81,11 @@ export const useBattleStore = create<BattleState>((set, get) => ({
       useTeamStore.getState().healTeam(healFraction);
       set({ status: 'won' });
     } else {
-      // Player lost
+      // Player lost: heal fully then prepare a new opponent after a short pause
+      useTeamStore.getState().healTeam(1);
       set({ status: 'lost' });
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await get().nextBattle();
     }
   },
   nextBattle: async () => {

--- a/store/teamStore.ts
+++ b/store/teamStore.ts
@@ -27,7 +27,7 @@ export const useTeamStore = create<TeamState>((set, get) => ({
   activeIndex: 0,
   setStarter: async (id, level) => {
     const pokemon = await getPokemon(id);
-    const battleMon = createBattlePokemon(pokemon, level);
+    const battleMon = createBattlePokemon(pokemon, level, true);
     set({
       team: [
         {
@@ -44,14 +44,14 @@ export const useTeamStore = create<TeamState>((set, get) => ({
     const { team, maxTeamSize } = get();
     if (team.length >= maxTeamSize) return;
     const pokemon = await getPokemon(id);
-    const battleMon = createBattlePokemon(pokemon, level);
+    const battleMon = createBattlePokemon(pokemon, level, true);
     set({ team: [...team, { pokemon, level, hp: battleMon.hp }] });
     persist(get());
   },
   healTeam: (fraction) => {
     set((state) => {
       const newTeam = state.team.map((member) => {
-        const baseHp = createBattlePokemon(member.pokemon, member.level).hp;
+        const baseHp = createBattlePokemon(member.pokemon, member.level, true).hp;
         const healed = Math.min(baseHp, member.hp + baseHp * fraction);
         return { ...member, hp: healed };
       });


### PR DESCRIPTION
## Summary
- grant player Pokémon level-based HP bonuses
- show an XP progress bar in the game header
- automatically heal and queue a new battle after a loss

## Testing
- `npm test tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68ad14ea16048323b77ef632fb76ccad