### PR TITLE
feat: add turn-based battles with move selection

### DIFF
--- a/components/BattleArena.tsx
+++ b/components/BattleArena.tsx
@@ -16,7 +16,10 @@ export function BattleArena() {
     startBattle,
     nextBattle,
     playerHp,
-    enemyHp
+    enemyHp,
+    playerMoves,
+    playerAttack,
+    turn
   } = useBattleStore();
   const { team } = useTeamStore();
   const t = useTranslate();
@@ -92,7 +95,7 @@ export function BattleArena() {
         </div>
       )}
       {/* Controls */}
-      <div className="mt-4">
+      <div className="mt-4 flex flex-col items-center space-y-2">
         {status === 'idle' && (
           <button
             className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded"
@@ -100,6 +103,25 @@ export function BattleArena() {
           >
             {t('startGame')}
           </button>
+        )}
+        {status === 'running' && (
+          <>
+            {turn === 'player' ? (
+              <div className="flex flex-wrap justify-center gap-2">
+                {playerMoves.map((move, idx) => (
+                  <button
+                    key={move.name}
+                    className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded"
+                    onClick={() => playerAttack(idx)}
+                  >
+                    {move.name}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="italic">{t('enemyTurn')}</div>
+            )}
+          </>
         )}
         {status === 'won' && (
           <button

--- a/lib/battle/engine.ts
+++ b/lib/battle/engine.ts
@@ -32,7 +32,7 @@ const typeChart: Record<string, Record<string, number>> = {
 
 /** Returns a list of moves appropriate for the Pokémon's primary type. If
  * no moves are defined for the first type, fallback to normal moves. */
-function getMovesForPokemon(pokemon: NormalisedPokemon): Move[] {
+export function getMovesForPokemon(pokemon: NormalisedPokemon): Move[] {
   const primaryType = pokemon.types[0] ?? 'normal';
   const moves = BASIC_MOVES[primaryType as keyof typeof BASIC_MOVES];
   return moves ?? BASIC_MOVES['normal'];
@@ -107,7 +107,7 @@ export function calculateDamage(
  * the highest power that is not on cooldown. In this simplified
  * implementation cooldown is ignored (all moves available every turn).
  */
-function chooseMove(pokemon: BattlePokemon): Move {
+export function chooseMove(pokemon: BattlePokemon): Move {
   const moves = getMovesForPokemon(pokemon.pokemon);
   // Pick highest power move
   return moves.reduce((best, move) => (move.power > best.power ? move : best), moves[0]);

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -29,8 +29,8 @@ export const dictionary: Dictionary = {
     mute: 'Mute',
     unmute: 'Unmute',
     reset: 'Reset Progress',
-    language: 'Language'
-    ,
+    language: 'Language',
+    enemyTurn: "Enemy's turn...",
     'choose your starter': 'Choose your starter'
   },
   es: {
@@ -52,8 +52,8 @@ export const dictionary: Dictionary = {
     mute: 'Silenciar',
     unmute: 'Activar sonido',
     reset: 'Reiniciar',
-    language: 'Idioma'
-    ,
+    language: 'Idioma',
+    enemyTurn: 'Turno del enemigo...',
     'choose your starter': 'Elige tu inicial'
   }
 };


### PR DESCRIPTION
## Summary
- export move helpers from battle engine for reuse
- add turn-based battle store with player-selected moves
- update arena UI and translations for turn system

## Testing
- `npm test` *(fails: Playwright Test did not expect test.describe() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1a4dd538832380a00f018cb49346