### PR TITLE
feat: animate battles and add pokemon capture

### DIFF
--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -23,7 +23,7 @@ export default function GamePage() {
   const settings = useSettingsStore();
   const t = useTranslate();
   const [selecting, setSelecting] = useState(false);
-  const [carouselId, setCarouselId] = useState(1);
+  const [choices, setChoices] = useState<number[]>([]);
 
   // If no team yet, start the selection overlay on mount
   useEffect(() => {
@@ -40,26 +40,19 @@ export default function GamePage() {
   }, [team.length, enemy, status]);
 
   function startSelection() {
+    const ids: number[] = [];
+    while (ids.length < 3) {
+      const id = Math.floor(Math.random() * 150) + 1;
+      if (!ids.includes(id)) ids.push(id);
+    }
+    setChoices(ids);
     setSelecting(true);
-    // Spin quickly through Pokémon IDs
-    let current = 1;
-    const interval = setInterval(() => {
-      current = (current % 150) + 1;
-      setCarouselId(current);
-    }, 50);
-    const timeout = setTimeout(async () => {
-      clearInterval(interval);
-      const selected = Math.floor(Math.random() * 150) + 1;
-      setCarouselId(selected);
-      // Wait a moment for the final sprite to display
-      setTimeout(async () => {
-        await setStarter(selected, 1);
-        // Reset selection overlay
-        setSelecting(false);
-        await nextBattle();
-      }, 1000);
-      clearTimeout(timeout);
-    }, 3000);
+  }
+
+  async function chooseStarter(id: number) {
+    await setStarter(id, 1);
+    setSelecting(false);
+    await nextBattle();
   }
 
   // Settings handlers
@@ -149,19 +142,20 @@ export default function GamePage() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           >
-            <div className="p-8 bg-white dark:bg-gray-900 rounded-lg shadow flex flex-col items-center">
-              <div className="text-xl font-semibold mb-4">{t('choose your starter')}</div>
-              <div className="w-40 h-40 relative mb-4">
-                {/* Display front sprite of current ID */}
-                {/* Use raw GitHub sprite for quick load */}
-                <img
-                  src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${carouselId}.png`}
-                  alt="pokemon"
-                  className="w-full h-full object-contain"
-                />
+            <div className="p-8 bg-white dark:bg-gray-900 rounded-lg shadow flex flex-col items-center space-y-4">
+              <div className="text-xl font-semibold">{t('choose your starter')}</div>
+              <div className="flex space-x-4">
+                {choices.map((id) => (
+                  <button key={id} onClick={() => chooseStarter(id)} className="flex flex-col items-center">
+                    <img
+                      src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png`}
+                      alt="pokemon"
+                      className="w-20 h-20 object-contain"
+                    />
+                    <span>#{id}</span>
+                  </button>
+                ))}
               </div>
-              <div className="text-center">#{carouselId}</div>
-              <div className="mt-4 text-sm text-gray-500">{t('startGame')}...</div>
             </div>
           </motion.div>
         )}

--- a/components/AudioManager.tsx
+++ b/components/AudioManager.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { createContext, PropsWithChildren, useContext, useEffect, useRef } from 'react';
+import { useSettingsStore } from '@/store/settingsStore';
+
+interface AudioContextValue {
+  playAttack: () => void;
+}
+
+const Ctx = createContext<AudioContextValue>({ playAttack: () => {} });
+
+export function useAudio() {
+  return useContext(Ctx);
+}
+
+export function AudioManager({ children }: PropsWithChildren) {
+  const { muted } = useSettingsStore();
+  const bgmRef = useRef<HTMLAudioElement>(null);
+  const attackRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    const bgm = bgmRef.current;
+    if (!bgm) return;
+    bgm.loop = true;
+    if (muted) {
+      bgm.pause();
+    } else {
+      bgm.play().catch(() => undefined);
+    }
+  }, [muted]);
+
+  const playAttack = () => {
+    if (muted) return;
+    const el = attackRef.current;
+    if (!el) return;
+    el.currentTime = 0;
+    el.play().catch(() => undefined);
+  };
+
+  return (
+    <Ctx.Provider value={{ playAttack }}>
+      <audio ref={bgmRef} src="/levelup.mp3" />
+      <audio ref={attackRef} src="/attack.mp3" />
+      {children}
+    </Ctx.Provider>
+  );
+}

--- a/components/BattleArena.tsx
+++ b/components/BattleArena.tsx
@@ -6,6 +6,8 @@ import { ProgressBar } from '@/components/ProgressBar';
 import { useTranslate } from '@/hooks/useTranslate';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
+import { useAudio } from '@/components/AudioManager';
+import { useEffect } from 'react';
 
 export function BattleArena() {
   const {
@@ -19,10 +21,14 @@ export function BattleArena() {
     enemyHp,
     playerMoves,
     playerAttack,
-    turn
+    turn,
+    pendingCapture,
+    captureEnemy,
+    declineCapture
   } = useBattleStore();
   const { team } = useTeamStore();
   const t = useTranslate();
+  const audio = useAudio();
   const player = team[0];
   const playerMaxHp = player ? createMaxHp(player) : 1;
   const enemyMaxHp = enemy ? createMaxHpEnemy(enemy, enemyLevel) : 1;
@@ -30,8 +36,45 @@ export function BattleArena() {
   const enemyHit = last?.attacker === 'player' && status === 'running';
   const playerHit = last?.attacker === 'enemy' && status === 'running';
 
+  useEffect(() => {
+    if (enemyHit || playerHit) {
+      audio.playAttack();
+    }
+  }, [enemyHit, playerHit, audio]);
+
+  const enemyAnimate =
+    status === 'won'
+      ? { scale: [1, 1.2, 0], opacity: [1, 0] }
+      : enemyHit
+      ? { x: [0, -20, 0] }
+      : {};
+  const playerAnimate =
+    status === 'lost'
+      ? { scale: [1, 0.8, 0], opacity: [1, 0] }
+      : playerHit
+      ? { x: [0, 20, 0] }
+      : {};
+
   return (
-    <div className="flex flex-col items-center space-y-4">
+    <div className="relative flex flex-col items-center space-y-4">
+      {enemyHit && (
+        <motion.div
+          key={log.length}
+          className="absolute w-4 h-4 bg-yellow-400 rounded-full"
+          initial={{ x: -100, y: 60, opacity: 1 }}
+          animate={{ x: 100, y: -60, opacity: 0 }}
+          transition={{ duration: 0.5 }}
+        />
+      )}
+      {playerHit && (
+        <motion.div
+          key={`e${log.length}`}
+          className="absolute w-4 h-4 bg-red-400 rounded-full"
+          initial={{ x: 100, y: -60, opacity: 1 }}
+          animate={{ x: -100, y: 60, opacity: 0 }}
+          transition={{ duration: 0.5 }}
+        />
+      )}
       {/* Enemy display */}
       {enemy && (
         <div className="flex flex-col items-center">
@@ -43,7 +86,7 @@ export function BattleArena() {
           </div>
           <motion.div
             className="w-32 h-32 relative"
-            animate={enemyHit ? { x: [0, -20, 0] } : {}}
+            animate={enemyAnimate}
             transition={{ duration: 0.4 }}
           >
             <Image
@@ -76,7 +119,7 @@ export function BattleArena() {
           </div>
           <motion.div
             className="w-32 h-32 relative"
-            animate={playerHit ? { x: [0, 20, 0] } : {}}
+            animate={playerAnimate}
             transition={{ duration: 0.4 }}
           >
             <Image
@@ -123,7 +166,26 @@ export function BattleArena() {
             )}
           </>
         )}
-        {status === 'won' && (
+        {status === 'won' && pendingCapture && (
+          <div className="flex flex-col items-center space-y-2">
+            <div>{t('captureQuestion')}</div>
+            <div className="flex space-x-2">
+              <button
+                className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded"
+                onClick={() => captureEnemy()}
+              >
+                {t('capture')}
+              </button>
+              <button
+                className="px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded"
+                onClick={() => declineCapture()}
+              >
+                {t('nextBattle')}
+              </button>
+            </div>
+          </div>
+        )}
+        {status === 'won' && !pendingCapture && (
           <button
             className="px-4 py-2 bg-green-500 hover:bg-green-600 text-white rounded"
             onClick={() => nextBattle()}

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import clsx from 'clsx';
+import { motion } from 'framer-motion';
 
 interface ProgressBarProps {
   value: number;
@@ -23,9 +24,10 @@ export function ProgressBar({ value, max, color = 'green', className }: Progress
   }[color] ?? 'bg-green-500';
   return (
     <div className={clsx('w-full h-3 rounded bg-gray-300', className)}>
-      <div
+      <motion.div
         className={clsx('h-full rounded', barColor)}
-        style={{ width: `${percentage}%` }}
+        animate={{ width: `${percentage}%` }}
+        transition={{ duration: 0.5 }}
       />
     </div>
   );

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -2,6 +2,7 @@
 
 import { PropsWithChildren, useEffect } from 'react';
 import { useSettingsStore } from '@/store/settingsStore';
+import { AudioManager } from '@/components/AudioManager';
 
 /**
  * Providers component is used to perform client‑side only hydration
@@ -17,5 +18,5 @@ export function Providers({ children }: PropsWithChildren) {
     hydrateSettings();
   }, [hydrateSettings]);
 
-  return <>{children}</>;
+  return <AudioManager>{children}</AudioManager>;
 }

--- a/components/TeamPanel.tsx
+++ b/components/TeamPanel.tsx
@@ -40,7 +40,7 @@ export function TeamPanel() {
           key={idx}
           className="p-2 bg-gray-200 dark:bg-gray-800 rounded flex items-center justify-center text-gray-500"
         >
-          Empty
+          {t('empty')}
         </div>
       ))}
     </div>

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -31,7 +31,10 @@ export const dictionary: Dictionary = {
     reset: 'Reset Progress',
     language: 'Language',
     enemyTurn: "Enemy's turn...",
-    'choose your starter': 'Choose your starter'
+    'choose your starter': 'Choose your starter',
+    empty: 'Empty',
+    capture: 'Capture',
+    captureQuestion: 'Capture this Pokémon?'
   },
   es: {
     play: 'Jugar',
@@ -54,6 +57,9 @@ export const dictionary: Dictionary = {
     reset: 'Reiniciar',
     language: 'Idioma',
     enemyTurn: 'Turno del enemigo...',
-    'choose your starter': 'Elige tu inicial'
+    'choose your starter': 'Elige tu inicial',
+    empty: 'Vacío',
+    capture: 'Capturar',
+    captureQuestion: '¿Capturar este Pokémon?'
   }
 };


### PR DESCRIPTION
## Summary
- add audio manager and projectile animations to battles
- localize team panel and enable starter selection
- support capturing defeated enemies to expand team

## Testing
- `npm test` *(fails: Playwright Test did not expect test.describe() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1fe515788323bf2f673215d3fb1f